### PR TITLE
docs: remove duplicated words

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ You can force a refresh of the current session token by calling `supabase.auth.r
 ##### find all users who have a `userlevel` over 100
 `select * from auth.users where (auth.users.raw_app_meta_data->'userlevel')::numeric > 100;`
 ##### find all users whose `userrole` is set to `"MANAGER"`
-(note for strings you need to add double-quotes becuase data is data is stored as JSONB)
+(note for strings you need to add double-quotes becuase data is stored as JSONB)
 `select * from auth.users where (auth.users.raw_app_meta_data->'userrole')::text = '"MANAGER"';`
 
 ### What's the difference between `auth.users.raw_app_meta_data` and `auth.users.raw_user_meta_data`?


### PR DESCRIPTION
## Scope
A dev girl should be able to read the section on using double quotes without having a sentence with duplicated words in.

## Work done
Removed "data is" from the sentence so that it now reads "note for strings you need to add double-quotes becuase data is stored as JSONB" instead of "(note for strings you need to add double-quotes becuase data is data is stored as JSONB)"

## Steps to test
Give it a read :)


## GIF tax
![](https://media.giphy.com/media/WyDeSN3uSva5ofUknw/giphy.gif)